### PR TITLE
Sync branch protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#44bf784ea04e2a8d75f0b558c86b64da95484f66"
+source = "git+https://github.com/rust-lang/team#e085b4ebaabd6867244803df10752542c3f1aef3"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#e085b4ebaabd6867244803df10752542c3f1aef3"
+source = "git+https://github.com/rust-lang/team#275d7de69868f48e11fe048e93cec4981566b9ff"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -506,7 +506,7 @@ impl GitHub {
 
     /// Get the head commit of the supplied branch
     pub(crate) fn branch(&self, repo: &Repo, name: &str) -> Result<Option<String>, Error> {
-        let mut resp = self
+        let resp = self
             .req(
                 Method::GET,
                 &format!("repos/{}/{}/branches/{}", repo.org, repo.name, name),

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -443,6 +443,7 @@ impl GitHub {
                 name: name.to_string(),
                 org: org.to_string(),
                 description: description.to_string(),
+                default_branch: "master".to_string(),
             })
         } else {
             Ok(self
@@ -454,7 +455,7 @@ impl GitHub {
         }
     }
 
-    pub(crate) fn edit_repo(&self, repo: Repo, description: &str) -> Result<(), Error> {
+    pub(crate) fn edit_repo(&self, repo: &Repo, description: &str) -> Result<(), Error> {
         #[derive(serde::Serialize)]
         struct Req<'a> {
             description: &'a str,
@@ -470,7 +471,7 @@ impl GitHub {
         Ok(())
     }
 
-    pub(crate) fn get_teams(&self, org: &str, repo: &str) -> Result<HashSet<String>, Error> {
+    pub(crate) fn teams(&self, org: &str, repo: &str) -> Result<HashSet<String>, Error> {
         let mut teams = HashSet::new();
 
         self.rest_paginated(&Method::GET, format!("repos/{org}/{repo}/teams"), |resp| {
@@ -499,6 +500,160 @@ impl GitHub {
             .error_for_status()?;
         } else {
             debug!("dry: removing team {team} from repo {org}/{repo}")
+        }
+        Ok(())
+    }
+
+    /// Get the head commit of the supplied branch
+    pub(crate) fn branch(&self, repo: &Repo, name: &str) -> Result<Option<String>, Error> {
+        let mut resp = self
+            .req(
+                Method::GET,
+                &format!("repos/{}/{}/branches/{}", repo.org, repo.name, name),
+            )?
+            .send()?;
+        match resp.status() {
+            StatusCode::OK => Ok(Some(resp.json::<Branch>()?.commit.sha)),
+            StatusCode::NOT_FOUND => Ok(None),
+            _ => Err(resp.error_for_status().unwrap_err().into()),
+        }
+    }
+
+    pub(crate) fn create_branch(&self, repo: &Repo, name: &str, commit: &str) -> Result<(), Error> {
+        #[derive(serde::Serialize)]
+        struct Req<'a> {
+            r#ref: &'a str,
+            sha: &'a str,
+        }
+        if self.dry_run {
+            debug!(
+                "dry: created branch in {}/{}: {} with commit {}",
+                repo.org, repo.name, name, commit
+            );
+            Ok(())
+        } else {
+            Ok(self
+                .req(
+                    Method::POST,
+                    &format!("repos/{}/{}/git/refs", repo.org, repo.name),
+                )?
+                .json(&Req {
+                    r#ref: &format!("refs/heads/{}", name),
+                    sha: commit,
+                })
+                .send()?
+                .error_for_status()?
+                .json()?)
+        }
+    }
+
+    pub(crate) fn update_branch_protection(
+        &self,
+        repo: &Repo,
+        branch_name: &str,
+        branch_protection: BranchProtection,
+    ) -> Result<(), Error> {
+        #[derive(serde::Serialize)]
+        struct Req<'a> {
+            required_status_checks: Req1<'a>,
+            enforce_admins: bool,
+            required_pull_request_reviews: Req2,
+            restrictions: HashMap<String, Vec<()>>,
+        }
+        #[derive(serde::Serialize)]
+        struct Req1<'a> {
+            strict: bool,
+            checks: Vec<Check<'a>>,
+        }
+        #[derive(serde::Serialize)]
+        struct Check<'a> {
+            context: &'a str,
+        }
+        #[derive(serde::Serialize)]
+        struct Req2 {
+            // Even though we don't want dismissal restrictions, it cannot be ommited
+            dismissal_restrictions: HashMap<(), ()>,
+            dismiss_stale_reviews: bool,
+            required_approving_review_count: u8,
+        }
+        let req = Req {
+            required_status_checks: Req1 {
+                strict: false,
+                checks: branch_protection
+                    .required_checks
+                    .iter()
+                    .map(|c| Check {
+                        context: c.as_str(),
+                    })
+                    .collect(),
+            },
+            enforce_admins: true,
+            required_pull_request_reviews: Req2 {
+                dismissal_restrictions: HashMap::new(),
+                dismiss_stale_reviews: branch_protection.dismiss_stale_reviews,
+                required_approving_review_count: branch_protection.required_approving_review_count,
+            },
+            restrictions: vec![
+                ("users".to_string(), Vec::new()),
+                ("teams".to_string(), Vec::new()),
+            ]
+            .into_iter()
+            .collect(),
+        };
+        if !self.dry_run {
+            self.req(
+                Method::PUT,
+                &format!(
+                    "repos/{}/{}/branches/{}/protection",
+                    repo.org, repo.name, branch_name
+                ),
+            )?
+            .json(&req)
+            .send()?
+            .error_for_status()?;
+        } else {
+            debug!(
+                "dry: updating branch protection on repo {}/{} for {}: {}",
+                repo.org,
+                repo.name,
+                branch_name,
+                serde_json::to_string_pretty(&req).unwrap_or_else(|_| "<invalid json>".to_string())
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn protected_branches(&self, repo: &Repo) -> Result<HashSet<String>, Error> {
+        let mut names = HashSet::new();
+        self.rest_paginated(
+            &Method::GET,
+            format!("repos/{}/{}/branches?protected=true", repo.org, repo.name),
+            |resp| {
+                let resp = resp.error_for_status()?.json::<Vec<Branch>>()?;
+                names.extend(resp.into_iter().map(|b| b.name));
+
+                Ok(())
+            },
+        )?;
+        Ok(names)
+    }
+
+    pub(crate) fn delete_branch_protection(&self, repo: &Repo, branch: &str) -> Result<(), Error> {
+        if !self.dry_run {
+            self.req(
+                Method::DELETE,
+                &format!(
+                    "repos/{}/{}/branches/{}/protection",
+                    repo.org, repo.name, branch
+                ),
+            )?
+            .send()?
+            .error_for_status()?;
+        } else {
+            debug!(
+                "dry: removing branch protection in {}/{} from {} branch",
+                repo.org, repo.name, branch
+            );
         }
         Ok(())
     }
@@ -568,6 +723,7 @@ pub(crate) struct Repo {
     #[serde(alias = "owner", deserialize_with = "repo_owner")]
     pub(crate) org: String,
     pub(crate) description: String,
+    pub(crate) default_branch: String,
 }
 
 fn repo_owner<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -619,4 +775,21 @@ fn user_node_id(id: usize) -> String {
 
 fn team_node_id(id: usize) -> String {
     base64::encode(&format!("04:Team{}", id))
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(crate) struct Branch {
+    pub(crate) name: String,
+    pub(crate) commit: Commit,
+}
+#[derive(serde::Deserialize, Debug)]
+pub(crate) struct Commit {
+    pub(crate) sha: String,
+}
+
+#[derive(Debug)]
+pub(crate) struct BranchProtection {
+    pub(crate) dismiss_stale_reviews: bool,
+    pub(crate) required_approving_review_count: u8,
+    pub(crate) required_checks: Vec<String>,
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -245,7 +245,7 @@ impl SyncGitHub {
                 &branch.name,
                 api::BranchProtection {
                     required_approving_review_count: 1,
-                    dismiss_stale_reviews: false,
+                    dismiss_stale_reviews: branch.dismiss_stale_review,
                     required_checks: branch.ci_checks.clone(),
                 },
             )?;

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -167,15 +167,13 @@ impl SyncGitHub {
         if !just_created {
             if actual_repo.description != expected_repo.description {
                 self.github
-                    .edit_repo(actual_repo, &expected_repo.description)?;
+                    .edit_repo(&actual_repo, &expected_repo.description)?;
             } else {
                 debug!("repo is in synced state");
             }
         }
 
-        let mut actual_teams = self
-            .github
-            .get_teams(&expected_repo.org, &expected_repo.name)?;
+        let mut actual_teams = self.github.teams(&expected_repo.org, &expected_repo.name)?;
         // Sync team and bot permissions
         for expected_team in &expected_repo.teams {
             use rust_team_data::v1;
@@ -214,6 +212,50 @@ impl SyncGitHub {
         for team in &actual_teams {
             self.github
                 .remove_team_from_repo(&expected_repo.org, &expected_repo.name, team)?;
+        }
+
+        let mut main_branch_commit = None;
+        let mut actual_branch_protections = self.github.protected_branches(&actual_repo)?;
+
+        for branch in &expected_repo.branches {
+            actual_branch_protections.remove(&branch.name);
+
+            // if the branch does not already exist, create it
+            if self.github.branch(&actual_repo, &branch.name)?.is_none() {
+                // First, we need the sha of the head of the main branch
+                let main_branch_commit = match main_branch_commit.as_ref() {
+                    Some(s) => s,
+                    None => {
+                        let head = self
+                            .github
+                            .branch(&actual_repo, &actual_repo.default_branch)?
+                            .ok_or_else(|| failure::format_err!("could not find default branch"))?;
+                        // cache the main branch head so we only need to get it once
+                        main_branch_commit.get_or_insert(head)
+                    }
+                };
+
+                self.github
+                    .create_branch(&actual_repo, &branch.name, main_branch_commit)?;
+            };
+
+            // Update the protection of the branch
+            self.github.update_branch_protection(
+                &actual_repo,
+                &branch.name,
+                api::BranchProtection {
+                    required_approving_review_count: 1,
+                    dismiss_stale_reviews: false,
+                    required_checks: branch.ci_checks.clone(),
+                },
+            )?;
+        }
+
+        // `actual_branch_protections` now contains the branch protections that were not expected
+        // but are still on GitHub. We now remove them.
+        for branch_protection in actual_branch_protections {
+            self.github
+                .delete_branch_protection(&actual_repo, &branch_protection)?;
         }
         Ok(())
     }


### PR DESCRIPTION
This builds off of https://github.com/rust-lang/team/pull/804 and syncs the definitions with GitHub.

This change is good enough to recreate the permissions on the team repo with one exception: the team repo currently dismisses stale reviews, but this sets the repo to not dismiss stale reviews. @Mark-Simulacrum was of the opinion that we should default to not dismissing stale reviews. This seems like a reasonable default, but I would argue it definitely does not make sense for the team repo as we want to ensure that every change has been reviewed carefully (after all - permissions are at stake). 