### PR TITLE
Do not create branch when there is no default branch commits

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -443,7 +443,6 @@ impl GitHub {
                 name: name.to_string(),
                 org: org.to_string(),
                 description: description.to_string(),
-                default_branch: "master".to_string(),
             })
         } else {
             Ok(self
@@ -502,49 +501,6 @@ impl GitHub {
             debug!("dry: removing team {team} from repo {org}/{repo}")
         }
         Ok(())
-    }
-
-    /// Get the head commit of the supplied branch
-    pub(crate) fn branch(&self, repo: &Repo, name: &str) -> Result<Option<String>, Error> {
-        let resp = self
-            .req(
-                Method::GET,
-                &format!("repos/{}/{}/branches/{}", repo.org, repo.name, name),
-            )?
-            .send()?;
-        match resp.status() {
-            StatusCode::OK => Ok(Some(resp.json::<Branch>()?.commit.sha)),
-            StatusCode::NOT_FOUND => Ok(None),
-            _ => Err(resp.error_for_status().unwrap_err().into()),
-        }
-    }
-
-    pub(crate) fn create_branch(&self, repo: &Repo, name: &str, commit: &str) -> Result<(), Error> {
-        #[derive(serde::Serialize)]
-        struct Req<'a> {
-            r#ref: &'a str,
-            sha: &'a str,
-        }
-        if self.dry_run {
-            debug!(
-                "dry: created branch in {}/{}: {} with commit {}",
-                repo.org, repo.name, name, commit
-            );
-            Ok(())
-        } else {
-            Ok(self
-                .req(
-                    Method::POST,
-                    &format!("repos/{}/{}/git/refs", repo.org, repo.name),
-                )?
-                .json(&Req {
-                    r#ref: &format!("refs/heads/{}", name),
-                    sha: commit,
-                })
-                .send()?
-                .error_for_status()?
-                .json()?)
-        }
     }
 
     pub(crate) fn update_branch_protection(
@@ -723,7 +679,6 @@ pub(crate) struct Repo {
     #[serde(alias = "owner", deserialize_with = "repo_owner")]
     pub(crate) org: String,
     pub(crate) description: String,
-    pub(crate) default_branch: String,
 }
 
 fn repo_owner<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -780,11 +735,6 @@ fn team_node_id(id: usize) -> String {
 #[derive(serde::Deserialize, Debug)]
 pub(crate) struct Branch {
     pub(crate) name: String,
-    pub(crate) commit: Commit,
-}
-#[derive(serde::Deserialize, Debug)]
-pub(crate) struct Commit {
-    pub(crate) sha: String,
 }
 
 #[derive(Debug)]

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -214,30 +214,10 @@ impl SyncGitHub {
                 .remove_team_from_repo(&expected_repo.org, &expected_repo.name, team)?;
         }
 
-        let mut main_branch_commit = None;
         let mut actual_branch_protections = self.github.protected_branches(&actual_repo)?;
 
         for branch in &expected_repo.branches {
             actual_branch_protections.remove(&branch.name);
-
-            // if the branch does not already exist, create it
-            if self.github.branch(&actual_repo, &branch.name)?.is_none() {
-                // First, we need the sha of the head of the main branch
-                let main_branch_commit = match main_branch_commit.as_ref() {
-                    Some(s) => s,
-                    None => {
-                        let head = self
-                            .github
-                            .branch(&actual_repo, &actual_repo.default_branch)?
-                            .ok_or_else(|| failure::format_err!("could not find default branch"))?;
-                        // cache the main branch head so we only need to get it once
-                        main_branch_commit.get_or_insert(head)
-                    }
-                };
-
-                self.github
-                    .create_branch(&actual_repo, &branch.name, main_branch_commit)?;
-            };
 
             // Update the protection of the branch
             self.github.update_branch_protection(

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -214,10 +214,32 @@ impl SyncGitHub {
                 .remove_team_from_repo(&expected_repo.org, &expected_repo.name, team)?;
         }
 
+        let mut main_branch_commit = None;
         let mut actual_branch_protections = self.github.protected_branches(&actual_repo)?;
 
         for branch in &expected_repo.branches {
             actual_branch_protections.remove(&branch.name);
+
+            // if the branch does not already exist, create it
+            if self.github.branch(&actual_repo, &branch.name)?.is_none() {
+                // First, we need the sha of the head of the main branch
+                let main_branch_commit = match main_branch_commit.as_ref() {
+                    Some(s) => s,
+                    None => {
+                        let head = self
+                            .github
+                            .branch(&actual_repo, &actual_repo.default_branch)?;
+                        // cache the main branch head so we only need to get it once
+                        main_branch_commit.get_or_insert(head)
+                    }
+                };
+
+                // If there is a main branch commit, create the new branch
+                if let Some(main_branch_commit) = main_branch_commit {
+                    self.github
+                        .create_branch(&actual_repo, &branch.name, main_branch_commit)?;
+                }
+            }
 
             // Update the protection of the branch
             let protection_result = self.github.update_branch_protection(


### PR DESCRIPTION
When creating a repo, we also attempt to create missing branches so that we can add branch protections. This does not work for brand new repos where the default branch has no commits in it as branches need to have some commit in order to be created.

This changes it so that the branches only get created if there is a main branch commit. This means that until someone pushes a main branch commit, none of the branch protections will be created. 

@Mark-Simulacrum this also speaks to potentially wanting to run this code more often so that things become consistent more quickly. 