### PR TITLE
Sync triage permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#275d7de69868f48e11fe048e93cec4981566b9ff"
+source = "git+https://github.com/rust-lang/team#ceaef17a03b51ad688029af0e575b658ef40c03f"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -724,6 +724,7 @@ pub(crate) enum RepoPermission {
     Write,
     Admin,
     Maintain,
+    Triage,
 }
 
 #[derive(serde::Deserialize, Debug)]

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -181,6 +181,7 @@ impl SyncGitHub {
                 v1::RepoPermission::Write => RepoPermission::Write,
                 v1::RepoPermission::Admin => RepoPermission::Admin,
                 v1::RepoPermission::Maintain => RepoPermission::Maintain,
+                v1::RepoPermission::Triage => RepoPermission::Triage,
             };
             actual_teams.remove(&expected_team.name);
             self.github.update_team_repo_permissions(


### PR DESCRIPTION
Fixes a bug where we were not syncing these permissions (which is currently blocking sync-team from running). 