### PR TITLE
Allow bors push access if listed as a bot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#ceaef17a03b51ad688029af0e575b658ef40c03f"
+source = "git+https://github.com/rust-lang/team#bcbce38d4e8ff250cbfb2db92be72d7fc45ff151"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -561,7 +561,7 @@ impl GitHub {
             required_status_checks: Req1<'a>,
             enforce_admins: bool,
             required_pull_request_reviews: Req2,
-            restrictions: HashMap<String, Vec<()>>,
+            restrictions: HashMap<String, Vec<String>>,
         }
         #[derive(serde::Serialize)]
         struct Req1<'a> {
@@ -597,7 +597,7 @@ impl GitHub {
                 required_approving_review_count: branch_protection.required_approving_review_count,
             },
             restrictions: vec![
-                ("users".to_string(), Vec::new()),
+                ("users".to_string(), branch_protection.allowed_users),
                 ("teams".to_string(), Vec::new()),
             ]
             .into_iter()
@@ -803,4 +803,5 @@ pub(crate) struct BranchProtection {
     pub(crate) dismiss_stale_reviews: bool,
     pub(crate) required_approving_review_count: u8,
     pub(crate) required_checks: Vec<String>,
+    pub(crate) allowed_users: Vec<String>,
 }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -250,6 +250,11 @@ impl SyncGitHub {
                     required_approving_review_count: 1,
                     dismiss_stale_reviews: branch.dismiss_stale_review,
                     required_checks: branch.ci_checks.clone(),
+                    allowed_users: expected_repo
+                        .bots
+                        .contains(&Bot::Bors)
+                        .then(|| vec!["bors".to_owned()])
+                        .unwrap_or_default(),
                 },
             )?;
             if !protection_result {


### PR DESCRIPTION
When bors is listed as a bot, give bors push access to protected branches. 