### PR TITLE
Diffs

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -212,34 +212,6 @@ impl GitHub {
 
     pub(crate) fn edit_team(
         &self,
-        team: &Team,
-        name: &str,
-        description: &str,
-        privacy: TeamPrivacy,
-    ) -> anyhow::Result<()> {
-        #[derive(serde::Serialize)]
-        struct Req<'a> {
-            name: &'a str,
-            description: &'a str,
-            privacy: TeamPrivacy,
-        }
-        if let (false, Some(id)) = (self.dry_run, team.id) {
-            self.req(Method::PATCH, &format!("teams/{}", id))?
-                .json(&Req {
-                    name,
-                    description,
-                    privacy,
-                })
-                .send()?
-                .error_for_status()?;
-        } else {
-            debug!("dry: edit team {}", name)
-        }
-        Ok(())
-    }
-
-    pub(crate) fn edit_team2(
-        &self,
         org: &str,
         name: &str,
         new_name: Option<&str>,
@@ -411,30 +383,6 @@ impl GitHub {
 
     pub(crate) fn set_membership(
         &self,
-        team: &Team,
-        username: &str,
-        role: TeamRole,
-    ) -> anyhow::Result<()> {
-        #[derive(serde::Serialize)]
-        struct Req {
-            role: TeamRole,
-        }
-        if let (false, Some(id)) = (self.dry_run, team.id) {
-            self.req(
-                Method::PUT,
-                &format!("teams/{}/memberships/{}", id, username),
-            )?
-            .json(&Req { role })
-            .send()?
-            .error_for_status()?;
-        } else {
-            debug!("dry: set membership of {} to {}", username, role);
-        }
-        Ok(())
-    }
-
-    pub(crate) fn set_membership2(
-        &self,
         org: &str,
         team: &str,
         username: &str,
@@ -461,21 +409,7 @@ impl GitHub {
         Ok(())
     }
 
-    pub(crate) fn remove_membership(&self, team: &Team, username: &str) -> anyhow::Result<()> {
-        if let (false, Some(id)) = (self.dry_run, team.id) {
-            self.req(
-                Method::DELETE,
-                &format!("teams/{}/memberships/{}", id, username),
-            )?
-            .send()?
-            .error_for_status()?;
-        } else {
-            debug!("dry: remove membership of {}", username);
-        }
-        Ok(())
-    }
-
-    pub(crate) fn remove_membership2(
+    pub(crate) fn remove_membership(
         &self,
         org: &str,
         team: &str,

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use hyper_old_types::header::{Link, RelationType};
-use log::{debug, info, trace};
+use log::{debug, trace};
 use reqwest::{
     blocking::{Client, RequestBuilder, Response},
     header::{self, HeaderValue},

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -785,7 +785,7 @@ impl GraphPageInfo {
 pub(crate) struct Team {
     /// The ID returned by the GitHub API can't be empty, but the None marks teams "created" during
     /// a dry run and not actually present on GitHub, so other methods can avoid acting on them.
-    id: Option<usize>,
+    pub(crate) id: Option<usize>,
     pub(crate) name: String,
     pub(crate) description: String,
     pub(crate) privacy: TeamPrivacy,

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -499,9 +499,9 @@ impl Diff {
     }
 
     /// Print out the diff to the logs
-    pub(crate) fn print_diff(&self) {
+    pub(crate) fn log(&self) {
         for team_diff in &self.team_diffs {
-            team_diff.print_diff()
+            team_diff.log()
         }
     }
 }
@@ -523,11 +523,11 @@ impl TeamDiff {
         Ok(())
     }
 
-    fn print_diff(&self) {
+    fn log(&self) {
         match self {
-            TeamDiff::Create(c) => c.print_diff(),
-            TeamDiff::Edit(e) => e.print_diff(),
-            TeamDiff::Delete(d) => d.print_diff(),
+            TeamDiff::Create(c) => c.log(),
+            TeamDiff::Edit(e) => e.log(),
+            TeamDiff::Delete(d) => d.log(),
         }
     }
 }
@@ -551,7 +551,7 @@ impl CreateTeamDiff {
         Ok(())
     }
 
-    fn print_diff(&self) {
+    fn log(&self) {
         info!("➕ Creating team:");
         info!("  Org: {}", self.org);
         info!("  Name: {}", self.name);
@@ -596,7 +596,7 @@ impl EditTeamDiff {
         Ok(())
     }
 
-    fn print_diff(&self) {
+    fn log(&self) {
         if self.noop() {
             debug!("✅ Team '{}' stays the same...", self.name);
             return;
@@ -670,7 +670,7 @@ impl DeleteTeamDiff {
         Ok(())
     }
 
-    fn print_diff(&self) {
+    fn log(&self) {
         info!("❌ Deleting team:");
         info!("  Org: {}", self.org);
         info!("  Name: {}", self.name);

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -490,6 +490,7 @@ pub(crate) struct Diff {
 }
 
 impl Diff {
+    /// Apply the diff to GitHub
     pub(crate) fn apply(self, sync: &SyncGitHub) -> anyhow::Result<()> {
         for team_diff in self.team_diffs {
             team_diff.apply(sync)?;
@@ -646,14 +647,15 @@ impl MemberDiff {
     fn apply(self, org: &str, team: &str, member: &str, sync: &SyncGitHub) -> anyhow::Result<()> {
         match self {
             MemberDiff::Create(role) | MemberDiff::ChangeRole((_, role)) => {
-                sync.github.set_membership(&org, &team, &member, role)?;
+                sync.github.set_membership(org, team, member, role)?;
             }
-            MemberDiff::Delete => sync.github.remove_membership(&org, &team, &member)?,
+            MemberDiff::Delete => sync.github.remove_membership(org, team, member)?,
             MemberDiff::Noop => {}
         }
 
         Ok(())
     }
+
     fn is_noop(&self) -> bool {
         matches!(self, Self::Noop)
     }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -165,7 +165,7 @@ impl SyncGitHub {
 
         Ok(TeamDiff::Edit(EditTeamDiff {
             org: github_team.org.clone(),
-            name: team.name.clone(),
+            name: team.name,
             name_diff,
             description_diff,
             privacy_diff,
@@ -178,7 +178,7 @@ impl SyncGitHub {
         Ok(())
     }
 
-    pub(crate) fn apply_team_diff(&self, diff: Vec<TeamDiff>) -> anyhow::Result<()> {
+    fn apply_team_diff(&self, diff: Vec<TeamDiff>) -> anyhow::Result<()> {
         let mut all_member_diffs = Vec::new();
         for team_diff in diff {
             match team_diff {
@@ -537,11 +537,13 @@ impl SyncGitHub {
     }
 }
 
+/// A diff between the team repo and the state on GitHub
 pub(crate) struct Diff {
     team_diffs: Vec<TeamDiff>,
 }
 
 impl Diff {
+    /// Print out the diff to the logs
     pub(crate) fn print_diff(&self) {
         for team_diff in &self.team_diffs {
             team_diff.print_diff()
@@ -549,14 +551,14 @@ impl Diff {
     }
 }
 
-pub(crate) enum TeamDiff {
+enum TeamDiff {
     Create(CreateTeamDiff),
     Edit(EditTeamDiff),
     Delete(DeleteTeamDiff),
 }
 
 impl TeamDiff {
-    pub(crate) fn print_diff(&self) {
+    fn print_diff(&self) {
         match self {
             TeamDiff::Create(c) => c.print_diff(),
             TeamDiff::Edit(e) => e.print_diff(),
@@ -565,7 +567,7 @@ impl TeamDiff {
     }
 }
 
-pub(crate) struct CreateTeamDiff {
+struct CreateTeamDiff {
     org: String,
     name: String,
     description: String,
@@ -593,7 +595,7 @@ impl CreateTeamDiff {
     }
 }
 
-pub(crate) struct EditTeamDiff {
+struct EditTeamDiff {
     org: String,
     name: String,
     name_diff: Option<String>,
@@ -601,6 +603,7 @@ pub(crate) struct EditTeamDiff {
     privacy_diff: Option<(TeamPrivacy, TeamPrivacy)>,
     member_diffs: Vec<(String, MemberDiff)>,
 }
+
 impl EditTeamDiff {
     fn print_diff(&self) {
         if self.noop() {
@@ -633,7 +636,7 @@ impl EditTeamDiff {
         }
     }
 
-    pub(crate) fn noop(&self) -> bool {
+    fn noop(&self) -> bool {
         self.name_diff.is_none()
             && self.description_diff.is_none()
             && self.privacy_diff.is_none()
@@ -654,10 +657,11 @@ impl MemberDiff {
     }
 }
 
-pub(crate) struct DeleteTeamDiff {
+struct DeleteTeamDiff {
     org: String,
     name: String,
 }
+
 impl DeleteTeamDiff {
     fn print_diff(&self) {
         info!("❌ Deleting team:");

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,7 @@ fn app() -> anyhow::Result<()> {
                 let token = get_env("GITHUB_TOKEN")?;
                 let sync = SyncGitHub::new(token, &team_api, dry_run)?;
                 let diff = sync.diff_all()?;
-                diff.print_diff();
+                diff.log();
                 diff.apply(&sync)?;
                 sync.synchronize_all()?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,9 +76,8 @@ fn app() -> anyhow::Result<()> {
                 let token = get_env("GITHUB_TOKEN")?;
                 let sync = SyncGitHub::new(token, &team_api, dry_run)?;
                 let diff = sync.diff_all()?;
-                for diff in diff {
-                    diff.print_diff();
-                }
+                diff.print_diff();
+                sync.apply_diff(diff)?;
                 sync.synchronize_all()?;
             }
             "mailgun" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ fn app() -> anyhow::Result<()> {
                 let sync = SyncGitHub::new(token, &team_api, dry_run)?;
                 let diff = sync.diff_all()?;
                 diff.print_diff();
-                sync.apply_diff(diff)?;
+                diff.apply(&sync)?;
                 sync.synchronize_all()?;
             }
             "mailgun" => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,10 @@ fn app() -> anyhow::Result<()> {
             "github" => {
                 let token = get_env("GITHUB_TOKEN")?;
                 let sync = SyncGitHub::new(token, &team_api, dry_run)?;
+                let diff = sync.diff_all()?;
+                for diff in diff {
+                    diff.print_diff();
+                }
                 sync.synchronize_all()?;
             }
             "mailgun" => {


### PR DESCRIPTION
For ease this is built on top of the changes already present in #15, so we should merge that before this is ready for final review. 

This is the start of breaking up the sync process into 2 steps: diffing, applying the diff. 

Currently only GitHub team sync has been converted. Also, after the diffing/diff application, the *full* team sync process runs. This means that even if we have bugs in the logic of the new diff process, they will be reversed by the legacy syncing process (module any operations that return errors). 