### PR TITLE
Sync individual repo collaborators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#bcbce38d4e8ff250cbfb2db92be72d7fc45ff151"
+source = "git+https://github.com/rust-lang/team#b196b9eda3d7b7f1f0552240fa40b1087f78728c"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -205,14 +205,12 @@ impl SyncGitHub {
             }
         }
 
-        let permission = |p| {
-            use rust_team_data::v1;
-            match p {
-                &v1::RepoPermission::Write => RepoPermission::Write,
-                &v1::RepoPermission::Admin => RepoPermission::Admin,
-                &v1::RepoPermission::Maintain => RepoPermission::Maintain,
-                &v1::RepoPermission::Triage => RepoPermission::Triage,
-            }
+        use rust_team_data::v1;
+        let permission = |p: &v1::RepoPermission| match *p {
+            v1::RepoPermission::Write => RepoPermission::Write,
+            v1::RepoPermission::Admin => RepoPermission::Admin,
+            v1::RepoPermission::Maintain => RepoPermission::Maintain,
+            v1::RepoPermission::Triage => RepoPermission::Triage,
         };
         let mut actual_teams = self.github.teams(&expected_repo.org, &expected_repo.name)?;
         let mut actual_collaborators = self


### PR DESCRIPTION
https://github.com/rust-lang/team/pull/875 adds information on individual repository collaborators. This sync that information with GitHub.