### PR TITLE
Cleanup GitHub Client

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -121,7 +121,7 @@ impl GitHub {
         }
         debug!("Updating permission for team {team} on {org}/{repo} to {permission:?}");
         if !self.dry_run {
-            let _ = self.send(
+            self.send(
                 Method::PUT,
                 &format!("orgs/{org}/teams/{team}/repos/{org}/{repo}"),
                 &Req { permission },
@@ -145,7 +145,7 @@ impl GitHub {
         }
         debug!("Updating permission for user {user} on {org}/{repo} to {permission:?}");
         if !self.dry_run {
-            let _ = self.send(
+            self.send(
                 Method::PUT,
                 &format!("repos/{org}/{repo}/collaborators/{user}"),
                 &Req { permission },
@@ -309,7 +309,7 @@ impl GitHub {
             role: TeamRole,
         }
         if !self.dry_run {
-            let _ = self.send(
+            self.send(
                 Method::PUT,
                 &format!("orgs/{org}/teams/{team}/memberships/{user}"),
                 &Req { role },
@@ -685,7 +685,7 @@ impl GitHub {
     fn send_option<T: DeserializeOwned>(
         &self,
         method: Method,
-        url: &String,
+        url: &str,
     ) -> Result<Option<T>, anyhow::Error> {
         let resp = self.req(method, url)?.send()?;
         match resp.status() {

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use hyper_old_types::header::{Link, RelationType};
-use log::{debug, error, trace};
+use log::{debug, trace};
 use reqwest::{
     blocking::{Client, RequestBuilder, Response},
     header::{self, HeaderValue},
@@ -668,17 +668,10 @@ impl GitHub {
         body: &T,
     ) -> Result<U, anyhow::Error> {
         Ok(self
-            .req(method.clone(), url)?
+            .req(method, url)?
             .json(body)
             .send()?
-            .error_for_status()
-            .map(move |e| {
-                error!(
-                    "Error status '{}' on request {method} {url} with body {body:?}",
-                    e.status()
-                );
-                e
-            })?
+            .error_for_status()?
             .json()?)
     }
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -350,10 +350,12 @@ impl SyncGitHub {
             v1::RepoPermission::Maintain => RepoPermission::Maintain,
             v1::RepoPermission::Triage => RepoPermission::Triage,
         };
-        let mut actual_teams = self.github.teams(&expected_repo.org, &expected_repo.name)?;
+        let mut actual_teams = self
+            .github
+            .repo_teams(&expected_repo.org, &expected_repo.name)?;
         let mut actual_collaborators = self
             .github
-            .collaborators(&expected_repo.org, &expected_repo.name)?;
+            .repo_collaborators(&expected_repo.org, &expected_repo.name)?;
 
         // Sync team and bot permissions
         for expected_team in &expected_repo.teams {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -265,7 +265,7 @@ impl SyncGitHub {
                         "{}: user {} has the role {} instead of {}, changing them...",
                         slug, username, member.role, expected_role
                     );
-                    self.github.set_membership(
+                    self.github.set_team_membership(
                         &github_team.org,
                         &github_team.name,
                         username,
@@ -287,7 +287,7 @@ impl SyncGitHub {
                 // method will be called again. Thankfully though in that case GitHub doesn't send
                 // yet another invitation email to the user, but treats the API call as a noop, so
                 // it's safe to do it multiple times.
-                self.github.set_membership(
+                self.github.set_team_membership(
                     &github_team.org,
                     &github_team.name,
                     username,
@@ -303,8 +303,11 @@ impl SyncGitHub {
                 "{}: user {} is not in the team anymore, removing them...",
                 slug, member.username
             );
-            self.github
-                .remove_membership(&github_team.org, &github_team.name, &member.username)?;
+            self.github.remove_team_membership(
+                &github_team.org,
+                &github_team.name,
+                &member.username,
+            )?;
         }
 
         Ok(())
@@ -660,9 +663,9 @@ impl MemberDiff {
     fn apply(self, org: &str, team: &str, member: &str, sync: &SyncGitHub) -> anyhow::Result<()> {
         match self {
             MemberDiff::Create(role) | MemberDiff::ChangeRole((_, role)) => {
-                sync.github.set_membership(org, team, member, role)?;
+                sync.github.set_team_membership(org, team, member, role)?;
             }
-            MemberDiff::Delete => sync.github.remove_membership(org, team, member)?,
+            MemberDiff::Delete => sync.github.remove_team_membership(org, team, member)?,
             MemberDiff::Noop => {}
         }
 


### PR DESCRIPTION
This might be easiest to review commit by commit. This PR does not change functionality. Instead it's largely a cosmetic change.

I hope to next move this code to the team repo where we will have a single GitHub client that both the team repo and sync-team can rely on. 