### PR TITLE
Run team sync tool on demand from CI

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -1,0 +1,22 @@
+name: Run
+on:
+  workflow_dispatch: {}
+
+jobs:
+  run:
+    name: Run the sync-team tool
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--sync-team
+          aws-region: us-west-1
+
+      - name: Start the synchronization tool
+        run: |
+          aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
+          cat output.json | python3 -m json.tool
+          


### PR DESCRIPTION
Allows the running of the team-sync tool on demand which can be useful when investigating potentially spurious failures.