### PR TITLE
Handle missing main branch for branch protections

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -332,8 +332,13 @@ impl GitHub {
         struct Req<'a> {
             name: &'a str,
             description: &'a str,
+            auto_init: bool,
         }
-        let req = &Req { name, description };
+        let req = &Req {
+            name,
+            description,
+            auto_init: true,
+        };
         debug!("Creating the repo {org}/{name} with {req:?}");
         if self.dry_run {
             Ok(Repo {

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -805,6 +805,8 @@ pub(crate) enum RepoPermission {
     Admin,
     Maintain,
     Triage,
+    #[serde(alias = "pull")]
+    Read,
 }
 
 impl fmt::Display for RepoPermission {
@@ -814,6 +816,7 @@ impl fmt::Display for RepoPermission {
             Self::Admin => write!(f, "admin"),
             Self::Maintain => write!(f, "maintain"),
             Self::Triage => write!(f, "triage"),
+            Self::Read => write!(f, "read"),
         }
     }
 }
@@ -896,7 +899,7 @@ pub(crate) mod branch_protection {
     pub(crate) struct BranchProtection {
         pub(crate) required_status_checks: RequiredStatusChecks,
         pub(crate) enforce_admins: EnforceAdmins,
-        pub(crate) required_pull_request_reviews: PullRequestReviews,
+        pub(crate) required_pull_request_reviews: Option<PullRequestReviews>,
         pub(crate) restrictions: Option<Restrictions>,
     }
 
@@ -926,7 +929,7 @@ pub(crate) mod branch_protection {
         pub(crate) required_approving_review_count: u8,
     }
 
-    #[derive(Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
     pub(crate) struct Restrictions {
         pub(crate) users: Vec<UserRestriction>,
         pub(crate) teams: Vec<String>,


### PR DESCRIPTION
This fixes two issues currently breaking the sync mechanism:
* Some older repo member permissions come back as "pull" instead of "read". We now handle this.
* Freshly created repos don't have main branches so we could not create branch protections. We now handle the missing branch gracefully and also auto init the repo so that it should always have an initial commit. 

~CI is failing due to #35~