### PR TITLE
Use correct graphql input types

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -595,7 +595,7 @@ impl GitHub {
             BranchProtectionOp::UpdateBranchProtection(id) => id,
         };
         let query = format!("
-        mutation($id: String!, $pattern:String!, $contexts: [String!], $dismissStale: bool, $reviewCount: int, $pushActorIds: [ID!]) {{
+        mutation($id: String!, $pattern:String!, $contexts: [String!], $dismissStale: Boolean, $reviewCount: Int, $pushActorIds: [ID!]) {{
             {mutation_name}(input: {{
                 {id_field}: $id, 
                 pattern: $pattern, 


### PR DESCRIPTION
Fixes the following error message:

> caused by: graphql error: bool isn't a defined input type (on $dismissStale)