### PR TITLE
Fix another wrong type

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -595,7 +595,7 @@ impl GitHub {
             BranchProtectionOp::UpdateBranchProtection(id) => id,
         };
         let query = format!("
-        mutation($id: String!, $pattern:String!, $contexts: [String!], $dismissStale: Boolean, $reviewCount: Int, $pushActorIds: [ID!]) {{
+        mutation($id: ID!, $pattern:String!, $contexts: [String!], $dismissStale: Boolean, $reviewCount: Int, $pushActorIds: [ID!]) {{
             {mutation_name}(input: {{
                 {id_field}: $id, 
                 pattern: $pattern, 


### PR DESCRIPTION
Fixes the error:

> Type mismatch on variable $id and argument branchProtectionRuleId (String! / ID!)


