### PR TITLE
Add `--require-confirmation` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +177,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -337,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -876,6 +905,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +961,7 @@ dependencies = [
  "anyhow",
  "base64 0.13.0",
  "env_logger",
+ "hex",
  "hyper-old-types",
  "indexmap",
  "log",
@@ -928,6 +969,7 @@ dependencies = [
  "rust_team_data",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
 ]
 
@@ -1039,9 +1081,9 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ base64 = "0.13"
 hyper-old-types = "0.11"
 tempfile = "3.3"
 serde_json = "1.0"
+sha2 = "0.10.6"
+hex = "0.4.3"
 
 [dev-dependencies]
 indexmap = "1.9"

--- a/src/confirmation.rs
+++ b/src/confirmation.rs
@@ -1,0 +1,79 @@
+use crate::zulip::api::ZulipApi;
+use crate::{get_env, run_diffs, ServiceDiff};
+use sha2::{Digest, Sha256};
+
+pub(crate) struct Confirmation {
+    zulip: ZulipApi,
+    stream: String,
+    topic: String,
+    base_url: String,
+
+    diffs: Vec<ServiceDiff>,
+    hash: String,
+}
+
+impl Confirmation {
+    pub(crate) fn new(diffs: Vec<ServiceDiff>) -> anyhow::Result<Self> {
+        let mut hash = Sha256::new();
+        hash.update(&serde_json::to_vec(&diffs).unwrap());
+        let hash = hex::encode(hash.finalize());
+
+        Ok(Self {
+            zulip: ZulipApi::new(
+                get_env("ZULIP_USERNAME")?,
+                get_env("ZULIP_API_TOKEN")?,
+                false,
+            ),
+            stream: get_env("CONFIRMATION_STREAM")?,
+            topic: get_env("CONFIRMATION_TOPIC")?,
+            base_url: get_env("CONFIRMATION_BASE_URL")?,
+            diffs,
+            hash,
+        })
+    }
+
+    pub(crate) fn run(self) -> anyhow::Result<()> {
+        if let Ok(expected) = get_env("CONFIRMATION_EXPECTED_HASH") {
+            let approver = get_env("CONFIRMATION_APPROVER")?;
+            if self.hash == expected {
+                run_diffs(self.diffs)?;
+                self.zulip.post_message(
+                    &self.stream,
+                    &self.topic,
+                    &format!("Applied diff `{expected}`\nApproved by: `{approver}`"),
+                )?;
+            } else {
+                let mut message = String::new();
+                message.push_str(
+                    "🚨 **The diff changed since the approval, please approve again!**\n\n",
+                );
+                self.send_approval_message(&mut message)?;
+            }
+        } else {
+            self.send_approval_message(&mut String::new())?;
+        }
+
+        Ok(())
+    }
+
+    fn send_approval_message(&self, buffer: &mut String) -> anyhow::Result<()> {
+        for diff in &self.diffs {
+            match diff {
+                ServiceDiff::GitHub { diff, .. } => {
+                    buffer.push_str("\n**GitHub:**\n```text\n");
+                    buffer.push_str(&format!("{diff}"));
+                    buffer.push_str("```")
+                }
+            }
+        }
+
+        buffer.push('\n');
+        buffer.push_str(&format!("Hash: `{}`\n", self.hash));
+        buffer.push_str(&format!(
+            "[Approve]({}/{}) (requires authentication)\n",
+            self.base_url, self.hash
+        ));
+
+        self.zulip.post_message(&self.stream, &self.topic, buffer)
+    }
+}

--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -978,7 +978,7 @@ fn team_node_id(id: usize) -> String {
     base64::encode(format!("04:Team{id}"))
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct BranchProtection {
     pub(crate) pattern: String,

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -454,6 +454,7 @@ fn construct_branch_protection(
 const BOTS_TEAMS: &[&str] = &["bors", "highfive", "rfcbot", "bots"];
 
 /// A diff between the team repo and the state on GitHub
+#[derive(serde::Serialize)]
 pub(crate) struct Diff {
     team_diffs: Vec<TeamDiff>,
     repo_diffs: Vec<RepoDiff>,
@@ -487,6 +488,7 @@ impl std::fmt::Display for Diff {
     }
 }
 
+#[derive(serde::Serialize)]
 enum RepoDiff {
     Create(CreateRepoDiff),
     Update(UpdateRepoDiff),
@@ -510,6 +512,7 @@ impl std::fmt::Display for RepoDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 struct CreateRepoDiff {
     org: String,
     name: String,
@@ -558,6 +561,7 @@ impl std::fmt::Display for CreateRepoDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 struct UpdateRepoDiff {
     org: String,
     name: String,
@@ -615,6 +619,7 @@ impl std::fmt::Display for UpdateRepoDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 struct RepoPermissionAssignmentDiff {
     collaborator: RepoCollaborator,
     diff: RepoPermissionDiff,
@@ -666,18 +671,20 @@ impl std::fmt::Display for RepoPermissionAssignmentDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 enum RepoPermissionDiff {
     Create(RepoPermission),
     Update(RepoPermission, RepoPermission),
     Delete(RepoPermission),
 }
 
-#[derive(Clone)]
+#[derive(serde::Serialize, Clone)]
 enum RepoCollaborator {
     Team(String),
     User(String),
 }
 
+#[derive(serde::Serialize)]
 struct BranchProtectionDiff {
     pattern: String,
     operation: BranchProtectionDiffOperation,
@@ -762,12 +769,14 @@ fn log_branch_protection(
     Ok(())
 }
 
+#[derive(serde::Serialize)]
 enum BranchProtectionDiffOperation {
     Create(api::BranchProtection),
     Update(String, api::BranchProtection, api::BranchProtection),
     Delete(String),
 }
 
+#[derive(serde::Serialize)]
 enum TeamDiff {
     Create(CreateTeamDiff),
     Edit(EditTeamDiff),
@@ -796,6 +805,7 @@ impl std::fmt::Display for TeamDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 struct CreateTeamDiff {
     org: String,
     name: String,
@@ -838,6 +848,7 @@ impl std::fmt::Display for CreateTeamDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 struct EditTeamDiff {
     org: String,
     name: String,
@@ -914,6 +925,7 @@ impl std::fmt::Display for EditTeamDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 enum MemberDiff {
     Create(TeamRole),
     ChangeRole((TeamRole, TeamRole)),
@@ -939,6 +951,7 @@ impl MemberDiff {
     }
 }
 
+#[derive(serde::Serialize)]
 struct DeleteTeamDiff {
     org: String,
     name: String,

--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -25,6 +25,18 @@ impl ZulipApi {
         }
     }
 
+    pub(crate) fn post_message(&self, stream: &str, topic: &str, body: &str) -> anyhow::Result<()> {
+        let mut form = HashMap::new();
+        form.insert("type", "stream");
+        form.insert("to", stream);
+        form.insert("topic", topic);
+        form.insert("content", body);
+
+        let resp = self.req(reqwest::Method::POST, "/messages", Some(form))?;
+        resp.error_for_status()?;
+        Ok(())
+    }
+
     /// Creates a Zulip user group with the supplied name, description, and members
     ///
     /// This is a noop if the user group already exists.

--- a/src/zulip/mod.rs
+++ b/src/zulip/mod.rs
@@ -1,4 +1,4 @@
-mod api;
+pub(crate) mod api;
 
 use crate::team_api::TeamApi;
 use api::{ZulipApi, ZulipUserGroup};


### PR DESCRIPTION
This PR adds the `--require-confirmation` flag, which requires out-of-band confirmation of changes before those are applied.

The confirmation works by posting the diff and an approval link in a Zulip stream rather than applying the changes straight away. The link is not implemented in this PR, but it's supposed to authenticate the user and then restart the build passing the approved diff hash as an environment variable. Once the approved diff hash is provided the changes will actually be applied.

The flag is not set in production yet, as the URL to authenticate the user and restart the build with the approved hash is not implemented yet.

This PR also implements the `GITHUB_IGNORED_ORGS` environment variable, which helps running the tool locally when you don't have full access to all of our orgs.