### PR TITLE
Zulip users may now hide their emails from admins

### DIFF
--- a/src/zulip/api.rs
+++ b/src/zulip/api.rs
@@ -182,8 +182,9 @@ struct ZulipUsers {
 /// A single Zulip user
 #[derive(Deserialize)]
 pub(crate) struct ZulipUser {
+    // Note: users may hide their emails
     #[serde(rename = "delivery_email")]
-    pub(crate) email: String,
+    pub(crate) email: Option<String>,
     pub(crate) user_id: usize,
 }
 

--- a/src/zulip/mod.rs
+++ b/src/zulip/mod.rs
@@ -31,7 +31,7 @@ fn get_user_group_definitions(
     let email_map = zulip_api
         .get_users()?
         .into_iter()
-        .map(|u| (u.email, u.user_id))
+        .filter_map(|u| u.email.map(|e| (e, u.user_id)))
         .collect::<BTreeMap<_, _>>();
     let user_group_definitions = team_api
         .get_zulip_groups()?


### PR DESCRIPTION
We were getting errors because we expected emails to always be present which may no longer be the case.