### PR TITLE
Gracefully handle when a team is a push allowance actor

### DIFF
--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -436,7 +436,11 @@ fn construct_branch_protection(
     let push_allowances = expected_repo
         .bots
         .contains(&Bot::Bors)
-        .then(|| vec!["bors".to_owned()])
+        .then(|| {
+            vec![api::PushAllowanceActor::User(api::UserPushAllowanceActor {
+                login: "bors".to_owned(),
+            })]
+        })
         .unwrap_or_default();
     api::BranchProtection {
         pattern: branch_protection.pattern.clone(),


### PR DESCRIPTION
If someone sets a team as a push allowance actor, don't error.

This does not yet allow setting a team in the repo config toml. That will be done in a follow up. 