### PR TITLE
Team descriptions can be null

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -127,7 +127,7 @@ impl GitHub {
                 // doesn't actually exist on GitHub
                 id: None,
                 name: name.to_string(),
-                description: description.to_string(),
+                description: Some(description.to_string()),
                 privacy,
                 slug: name.to_string(),
             })
@@ -889,7 +889,7 @@ pub(crate) struct Team {
     /// a dry run and not actually present on GitHub, so other methods can avoid acting on them.
     pub(crate) id: Option<usize>,
     pub(crate) name: String,
-    pub(crate) description: String,
+    pub(crate) description: Option<String>,
     pub(crate) privacy: TeamPrivacy,
     /// The slug usually matches the name but can differ.
     /// For example, a team named rustup.rs would have a slug rustup-rs.

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -139,8 +139,15 @@ impl SyncGitHub {
             name_diff = Some(github_team.name.clone())
         }
         let mut description_diff = None;
-        if team.description != DEFAULT_DESCRIPTION {
-            description_diff = Some((team.description.clone(), DEFAULT_DESCRIPTION.to_owned()));
+        match &team.description {
+            Some(description) => {
+                if description != DEFAULT_DESCRIPTION {
+                    description_diff = Some((description.clone(), DEFAULT_DESCRIPTION.to_owned()));
+                }
+            }
+            None => {
+                description_diff = Some((String::new(), DEFAULT_DESCRIPTION.to_owned()));
+            }
         }
         let mut privacy_diff = None;
         if team.privacy != DEFAULT_PRIVACY {


### PR DESCRIPTION
When a team does not have a description, GitHub's API sets the `description` field to `null`. This breaks deserialization, which expects the field to be set to a `String`.

This is most likely only an issue for teams that have not previously been managed by sync-team, e.g. when an existing organizations is added to the team repository.