### PR TITLE
Fix restricting pushes to bots

### DIFF
--- a/src/github/api.rs
+++ b/src/github/api.rs
@@ -663,7 +663,7 @@ impl GitHub {
                     // We restrict merges, if we have explicitly set some actors to be
                     // able to merge (i.e., we allow allow those with write permissions
                     // to merge *or* we only allow those in `push_actor_ids`)
-                    restricts_pushes: push_actor_ids.is_empty(),
+                    restricts_pushes: !push_actor_ids.is_empty(),
                     push_actor_ids: &push_actor_ids,
                 },
             )?;


### PR DESCRIPTION
While working on `sync-team`, I noticed that the diff always contained the same change (both locally and in production):

```
 Team Diffs:
    💻 Repo Diffs:
    📝 Editing repo 'rust-lang/libc':
      Branch Protections:
          main
            Allowances: [] => [User(UserPushAllowanceActor { login: "bors" })]
    📝 Editing repo 'rust-lang/project-stable-mir':
      Branch Protections:
          main
            Allowances: [] => [User(UserPushAllowanceActor { login: "bors" })]
```

Checking the implementation, it seems that we have a bug in our code that _disables_ restrictions when we have defined a push actor, which means the actor is never set by GitHub.