### PR TITLE
Remove redundant imports.

### DIFF
--- a/src/mailgun/mod.rs
+++ b/src/mailgun/mod.rs
@@ -189,7 +189,6 @@ fn extract<'a>(s: &'a str, prefix: &str, suffix: &str) -> &'a str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rust_team_data::email_encryption;
 
     #[test]
     fn test_build_route_actions() {


### PR DESCRIPTION
A recent release of nightly has started warning about redundant imports. This removes that warning.
