### PR TITLE
Fix clippy warning.

### DIFF
--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -137,7 +137,7 @@ impl SyncGitHub {
                     .iter()
                     .map(|member| {
                         let expected_role = self.expected_role(&github_team.org, *member);
-                        (self.usernames_cache[&member].clone(), expected_role)
+                        (self.usernames_cache[member].clone(), expected_role)
                     })
                     .collect();
                 return Ok(TeamDiff::Create(CreateTeamDiff {


### PR DESCRIPTION
A recent nightly has started issuing the `clippy::needless_borrow` warning for this particular expression.
