### PR TITLE
Sync the Repository homepage setting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#a01edf210bf3ba9e5a6e9b982526dd90bb0063b0"
+source = "git+https://github.com/rust-lang/team#676ca8437e18dc66dbf2661613177d5a4f50571c"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -256,6 +256,7 @@ pub(crate) struct Repo {
     #[serde(alias = "owner", deserialize_with = "repo_owner")]
     pub(crate) org: String,
     pub(crate) description: Option<String>,
+    pub(crate) homepage: Option<String>,
 }
 
 fn repo_owner<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -211,16 +211,19 @@ impl GitHubWrite {
         org: &str,
         name: &str,
         description: &str,
+        homepage: &Option<String>,
     ) -> anyhow::Result<Repo> {
         #[derive(serde::Serialize, Debug)]
         struct Req<'a> {
             name: &'a str,
             description: &'a str,
+            homepage: &'a Option<String>,
             auto_init: bool,
         }
         let req = &Req {
             name,
             description,
+            homepage,
             auto_init: true,
         };
         debug!("Creating the repo {org}/{name} with {req:?}");
@@ -230,6 +233,7 @@ impl GitHubWrite {
                 name: name.to_string(),
                 org: org.to_string(),
                 description: Some(description.to_string()),
+                homepage: homepage.clone(),
             })
         } else {
             Ok(self
@@ -243,13 +247,18 @@ impl GitHubWrite {
         &self,
         org: &str,
         repo_name: &str,
-        description: &str,
+        description: &Option<String>,
+        homepage: &Option<String>,
     ) -> anyhow::Result<()> {
         #[derive(serde::Serialize, Debug)]
         struct Req<'a> {
-            description: &'a str,
+            description: &'a Option<String>,
+            homepage: &'a Option<String>,
         }
-        let req = Req { description };
+        let req = Req {
+            description,
+            homepage,
+        };
         debug!("Editing repo {}/{} with {:?}", org, repo_name, req);
         if !self.dry_run {
             self.client


### PR DESCRIPTION
This adds syncing of the `homepage` repository setting added in https://github.com/rust-lang/team/pull/1353.

I decided to collect repository settings into a single struct with the expectation that we might add more settings in the future.
