### PR TITLE
Implement repository archiving and unarchiving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#676ca8437e18dc66dbf2661613177d5a4f50571c"
+source = "git+https://github.com/rust-lang/team#b465f42245be30da0ce3657d49c3eb8b9d48ac14"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -257,6 +257,7 @@ pub(crate) struct Repo {
     pub(crate) org: String,
     pub(crate) description: Option<String>,
     pub(crate) homepage: Option<String>,
+    pub(crate) archived: bool,
 }
 
 fn repo_owner<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -234,6 +234,7 @@ impl GitHubWrite {
                 org: org.to_string(),
                 description: Some(description.to_string()),
                 homepage: homepage.clone(),
+                archived: false,
             })
         } else {
             Ok(self
@@ -249,15 +250,19 @@ impl GitHubWrite {
         repo_name: &str,
         description: &Option<String>,
         homepage: &Option<String>,
+        archived: Option<bool>,
     ) -> anyhow::Result<()> {
         #[derive(serde::Serialize, Debug)]
         struct Req<'a> {
             description: &'a Option<String>,
             homepage: &'a Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            archived: Option<bool>,
         }
         let req = Req {
             description,
             homepage,
+            archived,
         };
         debug!("Editing repo {}/{} with {:?}", org, repo_name, req);
         if !self.dry_run {


### PR DESCRIPTION
Implements repository (un)archiving, based on https://github.com/rust-lang/team/pull/1165. If no archiving change was made, the `archived` attribute won't even be sent to GitHub.