### PR TITLE
Automatically set `delete_branch_on_merge` for repositories

### DIFF
--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -219,12 +219,14 @@ impl GitHubWrite {
             description: &'a str,
             homepage: &'a Option<String>,
             auto_init: bool,
+            delete_branch_on_merge: bool,
         }
         let req = &Req {
             name,
             description,
             homepage,
             auto_init: true,
+            delete_branch_on_merge: true,
         };
         debug!("Creating the repo {org}/{name} with {req:?}");
         if self.dry_run {
@@ -254,10 +256,12 @@ impl GitHubWrite {
         struct Req<'a> {
             description: &'a Option<String>,
             homepage: &'a Option<String>,
+            delete_branch_on_merge: bool,
         }
         let req = Req {
             description,
             homepage,
+            delete_branch_on_merge: true,
         };
         debug!("Editing repo {}/{} with {:?}", org, repo_name, req);
         if !self.dry_run {


### PR DESCRIPTION
This was [requested](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Configure.20repo.20to.20delete.20merged.20PR.20branches) for the `miri-test-libstd` repository, but I think that it's generally useful to set this everywhere, which this PR does.