### PR TITLE
Set `allow_auto_merge` on repositories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#b465f42245be30da0ce3657d49c3eb8b9d48ac14"
+source = "git+https://github.com/rust-lang/team#cb7f3bd728847b4e59f02898fe7bbcb37b4ffdbb"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -258,6 +258,7 @@ pub(crate) struct Repo {
     pub(crate) description: Option<String>,
     pub(crate) homepage: Option<String>,
     pub(crate) archived: bool,
+    pub(crate) allow_auto_merge: bool,
 }
 
 fn repo_owner<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -381,4 +382,5 @@ pub(crate) struct RepoSettings {
     pub description: Option<String>,
     pub homepage: Option<String>,
     pub archived: bool,
+    pub auto_merge_enabled: bool,
 }

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -375,3 +375,10 @@ pub(crate) enum BranchProtectionOp {
     CreateForRepo(String),
     UpdateBranchProtection(String),
 }
+
+#[derive(PartialEq)]
+pub(crate) struct RepoSettings {
+    pub description: Option<String>,
+    pub homepage: Option<String>,
+    pub archived: bool,
+}

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -247,21 +247,18 @@ impl GitHubWrite {
         &self,
         org: &str,
         repo_name: &str,
-        description: &Option<String>,
-        homepage: &Option<String>,
-        archived: Option<bool>,
+        settings: &RepoSettings,
     ) -> anyhow::Result<()> {
         #[derive(serde::Serialize, Debug)]
         struct Req<'a> {
-            description: &'a Option<String>,
-            homepage: &'a Option<String>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            archived: Option<bool>,
+            description: &'a Option<&'a str>,
+            homepage: &'a Option<&'a str>,
+            archived: bool,
         }
         let req = Req {
-            description,
-            homepage,
-            archived,
+            description: &settings.description.as_deref(),
+            homepage: &settings.homepage.as_deref(),
+            archived: settings.archived,
         };
         debug!("Editing repo {}/{} with {:?}", org, repo_name, req);
         if !self.dry_run {

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -218,12 +218,14 @@ impl GitHubWrite {
             description: &'a str,
             homepage: &'a Option<&'a str>,
             auto_init: bool,
+            allow_auto_merge: bool,
         }
         let req = &Req {
             name,
             description: settings.description.as_deref().unwrap_or_default(),
             homepage: &settings.homepage.as_deref(),
             auto_init: true,
+            allow_auto_merge: settings.auto_merge_enabled,
         };
         debug!("Creating the repo {org}/{name} with {req:?}");
         if self.dry_run {
@@ -234,6 +236,7 @@ impl GitHubWrite {
                 description: settings.description.clone(),
                 homepage: settings.homepage.clone(),
                 archived: false,
+                allow_auto_merge: settings.auto_merge_enabled,
             })
         } else {
             Ok(self
@@ -254,11 +257,13 @@ impl GitHubWrite {
             description: &'a Option<&'a str>,
             homepage: &'a Option<&'a str>,
             archived: bool,
+            allow_auto_merge: bool,
         }
         let req = Req {
             description: &settings.description.as_deref(),
             homepage: &settings.homepage.as_deref(),
             archived: settings.archived,
+            allow_auto_merge: settings.auto_merge_enabled,
         };
         debug!("Editing repo {}/{} with {:?}", org, repo_name, req);
         if !self.dry_run {

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -613,6 +613,7 @@ struct UpdateRepoDiff {
     org: String,
     name: String,
     repo_id: String,
+    // old, new
     settings_diff: (RepoSettings, RepoSettings),
     permission_diffs: Vec<RepoPermissionAssignmentDiff>,
     branch_protection_diffs: Vec<BranchProtectionDiff>,
@@ -627,18 +628,7 @@ impl UpdateRepoDiff {
 
     fn apply(&self, sync: &GitHubWrite) -> anyhow::Result<()> {
         if self.settings_diff.0 != self.settings_diff.1 {
-            let RepoSettings {
-                description,
-                homepage,
-                archived,
-            } = &self.settings_diff.1;
-            let archived_diff = if self.settings_diff.0.archived != *archived {
-                Some(*archived)
-            } else {
-                None
-            };
-
-            sync.edit_repo(&self.org, &self.name, description, homepage, archived_diff)?;
+            sync.edit_repo(&self.org, &self.name, &self.settings_diff.1)?;
         }
         for permission in &self.permission_diffs {
             permission.apply(sync, &self.org, &self.name)?;


### PR DESCRIPTION
`sync-team` part of https://github.com/rust-lang/team/pull/1377. Also did some refactoring of repo settings, since it was becoming cumbersome to pass around a bunch of independent variables around.