### PR TITLE
Fix `allow_auto_merge` in combination with repository archiving

### DIFF
--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -258,7 +258,8 @@ pub(crate) struct Repo {
     pub(crate) description: Option<String>,
     pub(crate) homepage: Option<String>,
     pub(crate) archived: bool,
-    pub(crate) allow_auto_merge: bool,
+    #[serde(default)]
+    pub(crate) allow_auto_merge: Option<bool>,
 }
 
 fn repo_owner<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -236,7 +236,7 @@ impl GitHubWrite {
                 description: settings.description.clone(),
                 homepage: settings.homepage.clone(),
                 archived: false,
-                allow_auto_merge: settings.auto_merge_enabled,
+                allow_auto_merge: Some(settings.auto_merge_enabled),
             })
         } else {
             Ok(self

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -261,7 +261,7 @@ impl SyncGitHub {
             description: actual_repo.description.clone(),
             homepage: actual_repo.homepage.clone(),
             archived: actual_repo.archived,
-            auto_merge_enabled: actual_repo.allow_auto_merge,
+            auto_merge_enabled: actual_repo.allow_auto_merge.unwrap_or(false),
         };
         let new_settings = RepoSettings {
             description: Some(expected_repo.description.clone()),


### PR DESCRIPTION
1) Archived repositories might not return non-required attributes, which `allow_auto_merge` is.
2) Archived repositories should not be modified.

~The `unwrap_or(false)` part isn't ideal, but in this case we simply cannot query the GH state, so there's probably no way to calculate the real diff. In theory, this could cause us to miss auto-enabling auto merge for a repository that is being unarchived, during the first sync, but it should be resolved on the following sync.~ Actually, it should be fine, as the diff won't be missed, since we are unarchiving in the first place, so there is some diff.