### PR TITLE
Synchronize GitHub app installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,7 +909,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#cb7f3bd728847b4e59f02898fe7bbcb37b4ffdbb"
+source = "git+https://github.com/rust-lang/team#c21e50b35eeb3a35e26001c79031537f224d5f2b"
 dependencies = [
  "chacha20poly1305",
  "getrandom",

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -113,7 +113,7 @@ impl HttpClient {
 
     fn rest_paginated<F, T>(&self, method: &Method, url: String, mut f: F) -> anyhow::Result<()>
     where
-        F: FnMut(Vec<T>) -> anyhow::Result<()>,
+        F: FnMut(T) -> anyhow::Result<()>,
         T: DeserializeOwned,
     {
         let mut next = Some(url);
@@ -249,9 +249,23 @@ impl fmt::Display for RepoPermission {
 }
 
 #[derive(serde::Deserialize, Debug)]
+pub(crate) struct OrgAppInstallation {
+    #[serde(rename = "id")]
+    pub(crate) installation_id: u64,
+    pub(crate) app_id: u64,
+}
+
+#[derive(serde::Deserialize, Debug)]
+pub(crate) struct RepoAppInstallation {
+    pub(crate) name: String,
+}
+
+#[derive(serde::Deserialize, Debug)]
 pub(crate) struct Repo {
     #[serde(rename = "node_id")]
     pub(crate) id: String,
+    #[serde(rename = "id")]
+    pub(crate) repo_id: u64,
     pub(crate) name: String,
     #[serde(alias = "owner", deserialize_with = "repo_owner")]
     pub(crate) org: String,

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -138,7 +138,7 @@ impl HttpClient {
                 }
             }
 
-            f(resp.json().with_context(|| {
+            f(resp.json_annotated().with_context(|| {
                 format!("Failed to deserialize response body for {method} request to '{next_url}'")
             })?)?;
         }

--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -262,8 +262,7 @@ pub(crate) struct RepoAppInstallation {
 
 #[derive(serde::Deserialize, Debug)]
 pub(crate) struct Repo {
-    #[serde(rename = "node_id")]
-    pub(crate) id: String,
+    pub(crate) node_id: String,
     #[serde(rename = "id")]
     pub(crate) repo_id: u64,
     pub(crate) name: String,

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -279,14 +279,33 @@ impl GitHubWrite {
         installation_id: u64,
         repository_id: u64,
     ) -> anyhow::Result<()> {
-        debug!("Adding installation {installation_id} to repository {repository_id}");
+        debug!("Adding repository {repository_id} to installation {installation_id}");
         if !self.dry_run {
             self.client
                 .req(
                     Method::PUT,
                     &format!("user/installations/{installation_id}/repositories/{repository_id}"),
                 )?
-                .send()?;
+                .send()?
+                .custom_error_for_status()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn remove_repo_from_app_installation(
+        &self,
+        installation_id: u64,
+        repository_id: u64,
+    ) -> anyhow::Result<()> {
+        debug!("Removing repository {repository_id} from installation {installation_id}");
+        if !self.dry_run {
+            self.client
+                .req(
+                    Method::DELETE,
+                    &format!("user/installations/{installation_id}/repositories/{repository_id}"),
+                )?
+                .send()?
+                .custom_error_for_status()?;
         }
         Ok(())
     }

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -230,7 +230,7 @@ impl GitHubWrite {
         debug!("Creating the repo {org}/{name} with {req:?}");
         if self.dry_run {
             Ok(Repo {
-                id: String::from("ID"),
+                node_id: String::from("ID"),
                 repo_id: 0,
                 name: name.to_string(),
                 org: org.to_string(),

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -231,6 +231,7 @@ impl GitHubWrite {
         if self.dry_run {
             Ok(Repo {
                 id: String::from("ID"),
+                repo_id: 0,
                 name: name.to_string(),
                 org: org.to_string(),
                 description: settings.description.clone(),
@@ -269,6 +270,23 @@ impl GitHubWrite {
         if !self.dry_run {
             self.client
                 .send(Method::PATCH, &format!("repos/{org}/{repo_name}"), &req)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn add_repo_to_app_installation(
+        &self,
+        installation_id: u64,
+        repository_id: u64,
+    ) -> anyhow::Result<()> {
+        debug!("Adding installation {installation_id} to repository {repository_id}");
+        if !self.dry_run {
+            self.client
+                .req(
+                    Method::PUT,
+                    &format!("user/installations/{installation_id}/repositories/{repository_id}"),
+                )?
+                .send()?;
         }
         Ok(())
     }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -337,7 +337,7 @@ impl SyncGitHub {
         Ok(RepoDiff::Update(UpdateRepoDiff {
             org: expected_repo.org.clone(),
             name: actual_repo.name,
-            repo_id: actual_repo.id,
+            repo_node_id: actual_repo.id,
             settings_diff: (old_settings, new_settings),
             permission_diffs,
             branch_protection_diffs,
@@ -745,7 +745,7 @@ impl std::fmt::Display for CreateRepoDiff {
 struct UpdateRepoDiff {
     org: String,
     name: String,
-    repo_id: String,
+    repo_node_id: String,
     // old, new
     settings_diff: (RepoSettings, RepoSettings),
     permission_diffs: Vec<RepoPermissionAssignmentDiff>,
@@ -786,7 +786,7 @@ impl UpdateRepoDiff {
         }
 
         for branch_protection in &self.branch_protection_diffs {
-            branch_protection.apply(sync, &self.org, &self.name, &self.repo_id)?;
+            branch_protection.apply(sync, &self.org, &self.name, &self.repo_node_id)?;
         }
         Ok(())
     }

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -384,10 +384,12 @@ fn calculate_permission_diffs(
         permissions.push(diff);
     }
     // Bot permissions
-    let bots = expected_repo.bots.iter().map(|b| {
-        let bot_name = bot_name(b);
+    let bots = expected_repo.bots.iter().filter_map(|b| {
+        let Some(bot_name) = bot_name(b) else {
+            return None;
+        };
         actual_teams.remove(bot_name);
-        (bot_name, RepoPermission::Write)
+        Some((bot_name, RepoPermission::Write))
     });
     // Member permissions
     let members = expected_repo
@@ -441,13 +443,14 @@ fn calculate_permission_diffs(
     Ok(permissions)
 }
 
-fn bot_name(bot: &Bot) -> &str {
+/// Returns `None` if the bot is not an actual bot user, but rather a GitHub app.
+fn bot_name(bot: &Bot) -> Option<&str> {
     match bot {
-        Bot::Bors => "bors",
-        Bot::Highfive => "rust-highfive",
-        Bot::RustTimer => "rust-timer",
-        Bot::Rustbot => "rustbot",
-        Bot::Rfcbot => "rfcbot",
+        Bot::Bors => Some("bors"),
+        Bot::Highfive => Some("rust-highfive"),
+        Bot::RustTimer => Some("rust-timer"),
+        Bot::Rustbot => Some("rustbot"),
+        Bot::Rfcbot => Some("rfcbot"),
     }
 }
 

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -337,7 +337,7 @@ impl SyncGitHub {
         Ok(RepoDiff::Update(UpdateRepoDiff {
             org: expected_repo.org.clone(),
             name: actual_repo.name,
-            repo_node_id: actual_repo.id,
+            repo_node_id: actual_repo.node_id,
             settings_diff: (old_settings, new_settings),
             permission_diffs,
             branch_protection_diffs,
@@ -699,7 +699,7 @@ impl CreateRepoDiff {
                 pattern: branch.clone(),
                 operation: BranchProtectionDiffOperation::Create(protection.clone()),
             }
-            .apply(sync, &self.org, &self.name, &repo.id)?;
+            .apply(sync, &self.org, &self.name, &repo.node_id)?;
         }
 
         for installation in &self.app_installations {

--- a/src/github/tests/test_utils.rs
+++ b/src/github/tests/test_utils.rs
@@ -4,7 +4,8 @@ use derive_builder::Builder;
 use rust_team_data::v1::{GitHubTeam, Person, TeamGitHub, TeamKind};
 
 use crate::github::api::{
-    BranchProtection, GithubRead, Repo, RepoTeam, RepoUser, Team, TeamMember, TeamPrivacy, TeamRole,
+    BranchProtection, GithubRead, OrgAppInstallation, Repo, RepoAppInstallation, RepoTeam,
+    RepoUser, Team, TeamMember, TeamPrivacy, TeamRole,
 };
 use crate::github::{api, SyncGitHub, TeamDiff};
 
@@ -215,6 +216,17 @@ impl GithubRead for GithubMock {
             .unwrap_or_default()
             .into_iter()
             .collect())
+    }
+
+    fn org_app_installations(&self, _org: &str) -> anyhow::Result<Vec<OrgAppInstallation>> {
+        Ok(vec![])
+    }
+
+    fn app_installation_repos(
+        &self,
+        _installation_id: u64,
+    ) -> anyhow::Result<Vec<RepoAppInstallation>> {
+        Ok(vec![])
     }
 
     fn org_teams(&self, org: &str) -> anyhow::Result<Vec<(String, String)>> {


### PR DESCRIPTION
This PR implements addition and removal of repositories to GitHub app installations. Supported apps are specific variants of the `v1::Repo::Bot` enum, the first supported app is `RenovateBot`. To add a new app, it just needs to be added to the enum in `team` and also here, with its app ID.

**Needs https://github.com/rust-lang/team/pull/1410 to be merged first!**