### PR TITLE
CI: add dry run workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   ci:
@@ -18,6 +18,11 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      - name: Dry run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_API_READ_TOKEN }}
+        run: cargo run -- --only-print-plan github
 
       - name: Build the Docker container
         run: docker build -t sync-team .

--- a/.github/workflows/dry_run.yml
+++ b/.github/workflows/dry_run.yml
@@ -1,0 +1,24 @@
+# Smoke test that checks if we can download team data and read from the GitHub API.
+name: Dry run
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Try to dry run every 4 hours
+    - cron: "0 */4 * * *"
+
+jobs:
+  run:
+    name: Perform a dry run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Dry run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_API_READ_TOKEN }}
+        run: cargo run -- --only-print-plan github


### PR DESCRIPTION
This should help catch issues where `team` gets updated in a breaking way, but `sync-team` is not synchronized yet.

The check happens on PRs, but also repeatedly every 4 hours, to give us a heads-up if the dry run fails. It can also be executed manually to test `sync-team`.

This PR requires a `GITHUB_API_READ_TOKEN` secret to be configured for this repository. It should contain a GitHub API token with read-only permissions for the `rust-lang` organization.