### PR TITLE
CI: pin Rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust 1.77.0
-        run: |
-          rustc -vV
-          rustup install 1.77.0
-          rustup default 1.77.0
-          rustc -vV
-          rustup component add rustfmt clippy
-
       - name: Run rustfmt
         run: cargo fmt -- --check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust Stable
+      - name: Install Rust 1.77.0
         run: |
           rustc -vV
-          rustup update stable
-          rustup default stable
+          rustup install 1.77.0
+          rustup default 1.77.0
           rustc -vV
+          rustup component add rustfmt clippy
 
       - name: Run rustfmt
         run: cargo fmt -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Rust Stable
         run: |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.78.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
To avoid surprises with e.g. new Clippy errors breaking CI.