### PR TITLE
Disable "Require branches to be up-to-date" for branch protections

### DIFF
--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -429,7 +429,9 @@ impl GitHubWrite {
                 {id_field}: $id, 
                 pattern: $pattern, 
                 requiresStatusChecks: true, 
-                requiredStatusCheckContexts: $contexts, 
+                requiredStatusCheckContexts: $contexts,
+                # Disable 'Require branch to be up-to-date before merging'
+                requiresStrictStatusChecks: false,
                 isAdminEnforced: true, 
                 requiredApprovingReviewCount: $reviewCount, 
                 dismissesStaleReviews: $dismissStale, 


### PR DESCRIPTION
Documented [here](https://docs.github.com/en/graphql/reference/input-objects#createbranchprotectionruleinput).

Discussion: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/enforced.20branch.20updates.20on.20the.20blog.20repo