### PR TITLE
Add branch protection tests

### DIFF
--- a/src/github/api/read.rs
+++ b/src/github/api/read.rs
@@ -48,6 +48,7 @@ pub(crate) trait GithubRead {
     fn repo_collaborators(&self, org: &str, repo: &str) -> anyhow::Result<Vec<RepoUser>>;
 
     /// Get branch_protections
+    /// Returns a map branch pattern -> (protection ID, protection data)
     fn branch_protections(
         &self,
         org: &str,

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -606,7 +606,7 @@ pub fn convert_permission(p: &rust_team_data::v1::RepoPermission) -> RepoPermiss
     }
 }
 
-fn construct_branch_protection(
+pub fn construct_branch_protection(
     expected_repo: &rust_team_data::v1::Repo,
     branch_protection: &rust_team_data::v1::BranchProtection,
 ) -> api::BranchProtection {


### PR DESCRIPTION
Re-adds branch protection test logic that was originally included in https://github.com/rust-lang/sync-team/pull/65.