### PR TITLE
Only run the dry-run workflow in the rust-lang organization

### DIFF
--- a/.github/workflows/dry-run.yml
+++ b/.github/workflows/dry-run.yml
@@ -11,6 +11,7 @@ jobs:
   dry-run:
     name: Run sync-team dry-run
     runs-on: ubuntu-24.04
+    if: ${{ github.repository_owner == 'rust-lang' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
To avoid angry e-mails from GitHub on forks :)