### PR TITLE
Change repository description to not be optional

### DIFF
--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -274,7 +274,8 @@ pub(crate) struct Repo {
     pub(crate) name: String,
     #[serde(alias = "owner", deserialize_with = "repo_owner")]
     pub(crate) org: String,
-    pub(crate) description: Option<String>,
+    #[serde(default)]
+    pub(crate) description: String,
     pub(crate) homepage: Option<String>,
     pub(crate) archived: bool,
     #[serde(default)]
@@ -400,7 +401,7 @@ pub(crate) enum BranchProtectionOp {
 
 #[derive(PartialEq, Debug)]
 pub(crate) struct RepoSettings {
-    pub description: Option<String>,
+    pub description: String,
     pub homepage: Option<String>,
     pub archived: bool,
     pub auto_merge_enabled: bool,

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -228,7 +228,7 @@ impl GitHubWrite {
         }
         let req = &Req {
             name,
-            description: settings.description.as_deref().unwrap_or_default(),
+            description: &settings.description,
             homepage: &settings.homepage.as_deref(),
             auto_init: true,
             allow_auto_merge: settings.auto_merge_enabled,
@@ -261,13 +261,13 @@ impl GitHubWrite {
     ) -> anyhow::Result<()> {
         #[derive(serde::Serialize, Debug)]
         struct Req<'a> {
-            description: &'a Option<&'a str>,
+            description: &'a str,
             homepage: &'a Option<&'a str>,
             archived: bool,
             allow_auto_merge: bool,
         }
         let req = Req {
-            description: &settings.description.as_deref(),
+            description: &settings.description,
             homepage: &settings.homepage.as_deref(),
             archived: settings.archived,
             allow_auto_merge: settings.auto_merge_enabled,

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -312,7 +312,7 @@ impl SyncGitHub {
                     org: expected_repo.org.clone(),
                     name: expected_repo.name.clone(),
                     settings: RepoSettings {
-                        description: Some(expected_repo.description.clone()),
+                        description: expected_repo.description.clone(),
                         homepage: expected_repo.homepage.clone(),
                         archived: false,
                         auto_merge_enabled: expected_repo.auto_merge_enabled,
@@ -333,7 +333,7 @@ impl SyncGitHub {
             auto_merge_enabled: actual_repo.allow_auto_merge.unwrap_or(false),
         };
         let new_settings = RepoSettings {
-            description: Some(expected_repo.description.clone()),
+            description: expected_repo.description.clone(),
             homepage: expected_repo.homepage.clone(),
             archived: expected_repo.archived,
             auto_merge_enabled: expected_repo.auto_merge_enabled,
@@ -858,12 +858,11 @@ impl std::fmt::Display for UpdateRepoDiff {
             archived,
             auto_merge_enabled,
         } = settings_old;
-        match (description, &settings_new.description) {
-            (None, Some(new)) => writeln!(f, "  Set description: '{new}'")?,
-            (Some(old), None) => writeln!(f, "  Remove description: '{old}'")?,
-            (Some(old), Some(new)) if old != new => {
-                writeln!(f, "  New description: '{old}' => '{new}'")?
-            }
+        match (description.as_str(), settings_new.description.as_str()) {
+            ("", "") => {}
+            ("", new) => writeln!(f, "  Set description: '{new}'")?,
+            (old, "") => writeln!(f, "  Remove description: '{old}'")?,
+            (old, new) if old != new => writeln!(f, "  New description: '{old}' => '{new}'")?,
             _ => {}
         }
         match (homepage, &settings_new.homepage) {

--- a/src/github/tests/mod.rs
+++ b/src/github/tests/mod.rs
@@ -226,17 +226,13 @@ fn repo_change_description() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "foo",
-                        ),
+                        description: "foo",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "bar",
-                        ),
+                        description: "bar",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -269,9 +265,7 @@ fn repo_change_homepage() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: Some(
                             "https://foo.rs",
                         ),
@@ -279,9 +273,7 @@ fn repo_change_homepage() {
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: Some(
                             "https://bar.rs",
                         ),
@@ -323,9 +315,7 @@ fn repo_create() {
                 org: "rust-lang",
                 name: "repo1",
                 settings: RepoSettings {
-                    description: Some(
-                        "foo",
-                    ),
+                    description: "foo",
                     homepage: None,
                     archived: false,
                     auto_merge_enabled: false,
@@ -396,17 +386,13 @@ fn repo_add_member() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -454,17 +440,13 @@ fn repo_change_member_permissions() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -508,17 +490,13 @@ fn repo_remove_member() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -563,17 +541,13 @@ fn repo_add_team() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -616,17 +590,13 @@ fn repo_change_team_permissions() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -670,17 +640,13 @@ fn repo_remove_team() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -723,17 +689,13 @@ fn repo_archive_repo() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: true,
                         auto_merge_enabled: false,
@@ -770,17 +732,13 @@ fn repo_add_branch_protection() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -870,17 +828,13 @@ fn repo_update_branch_protection() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
@@ -951,17 +905,13 @@ fn repo_remove_branch_protection() {
                 repo_id: 0,
                 settings_diff: (
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,
                     },
                     RepoSettings {
-                        description: Some(
-                            "",
-                        ),
+                        description: "",
                         homepage: None,
                         archived: false,
                         auto_merge_enabled: false,

--- a/src/github/tests/test_utils.rs
+++ b/src/github/tests/test_utils.rs
@@ -119,7 +119,7 @@ impl DataModel {
                     node_id: repos.len().to_string(),
                     name: repo.name.clone(),
                     org: DEFAULT_ORG.to_string(),
-                    description: Some(repo.description.clone()),
+                    description: repo.description.clone(),
                     homepage: repo.homepage.clone(),
                     archived: false,
                     allow_auto_merge: None,


### PR DESCRIPTION
There was kind of a double empty state for repository descriptions (`None` or `Some("")`), which was causing unnecessary diffs to be displayed in logs (and performed in the API).

Missing or empty description is pretty much the same, and furthermore `team` requires the description field on each repository, so it shouldn't even ever be completely missing anyway (although it might be empty).

This was one of the sources of fake/extra diffs in sync-team dry-run (but also live) output.