### PR TITLE
Normalize order of branch protection checks

### DIFF
--- a/src/github/api/read.rs
+++ b/src/github/api/read.rs
@@ -392,13 +392,15 @@ impl GithubRead for GitHubApiRead {
 
         let mut result = HashMap::new();
         let res: Wrapper = self.client.graphql(QUERY, Params { org, repo }, org)?;
-        for node in res
+        for mut node in res
             .repository
             .branch_protection_rules
             .nodes
             .into_iter()
             .flatten()
         {
+            // Normalize check order to avoid diffs based only on the ordering difference
+            node.protection.required_status_check_contexts.sort();
             result.insert(node.protection.pattern.clone(), (node.id, node.protection));
         }
         Ok(result)

--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -641,17 +641,22 @@ pub fn construct_branch_protection(
             login: "bors".to_owned(),
         }));
     }
+
+    let mut checks = match &branch_protection.mode {
+        BranchProtectionMode::PrRequired { ci_checks, .. } => ci_checks.clone(),
+        BranchProtectionMode::PrNotRequired => {
+            vec![]
+        }
+    };
+    // Normalize check order to avoid diffs based only on the ordering difference
+    checks.sort();
+
     api::BranchProtection {
         pattern: branch_protection.pattern.clone(),
         is_admin_enforced: true,
         dismisses_stale_reviews: branch_protection.dismiss_stale_review,
         required_approving_review_count,
-        required_status_check_contexts: match &branch_protection.mode {
-            BranchProtectionMode::PrRequired { ci_checks, .. } => ci_checks.clone(),
-            BranchProtectionMode::PrNotRequired => {
-                vec![]
-            }
-        },
+        required_status_check_contexts: checks,
         push_allowances,
         requires_approving_reviews: matches!(
             branch_protection.mode,

--- a/src/github/tests/mod.rs
+++ b/src/github/tests/mod.rs
@@ -909,8 +909,8 @@ fn repo_update_branch_protection() {
                                 dismisses_stale_reviews: true,
                                 required_approving_review_count: 0,
                                 required_status_check_contexts: [
-                                    "test",
                                     "Test",
+                                    "test",
                                 ],
                                 push_allowances: [],
                                 requires_approving_reviews: true,


### PR DESCRIPTION
To avoid spurious diffs, as it seems that the ordering is not necessarily kept by GitHub.

This should fix one spurious diff from production:
```
📝 Editing repo 'rust-lang/infra-smoke-tests':
      Branch Protections:
          main
            Required Checks: ["Run tests", "Check Markdown style", "Check JSON style", "Check Rust style", "Check YAML style", "Lint Markdown files", "Lint Rust code", "Lint YAML files"] => ["Check Markdown style", "Check JSON style", "Check Rust style", "Check YAML style", "Lint Markdown files", "Lint Rust code", "Lint YAML files", "Run tests"]
```
I assume that it's spurious, because it was in the log today, but this repo probably didn't change its protections recently? Another reason why the might be the diff is that the production token cannot update the checks of this repo, but that seems unlikely.

Another solution to this could be to manually implement `PartialEq` for the branch protection, but that didn't feel right.