### PR TITLE
Switch CI to use a merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,40 +4,48 @@ on:
   merge_group:
 
 jobs:
-  ci:
-    name: CI
+  test:
+    name: Test
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     steps:
       - uses: actions/checkout@v4
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build
+        run: cargo build
+
+      - name: Run tests
+        run: cargo test
 
       - name: Run rustfmt
         run: cargo fmt -- --check
 
       - name: Run clippy
         run: cargo clippy -- -Dwarnings
-
-      - name: Run tests
-        run: cargo test
-
+  deploy:
+    name: Deploy
+    needs: [ test ]
+    environment: deploy
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    if: github.event_name == 'merge_group'
+    steps:
       - name: Build the Docker container
         run: docker build -t sync-team .
 
       - name: Configure AWS credentials
-        if: github.event_name == 'merge_group'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--sync-team
           aws-region: us-west-1
 
       - name: Login to Amazon ECR Private
-        if: github.event_name == 'merge_group'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build, tag, and push docker image to Amazon ECR
-        if: github.event_name == 'merge_group'
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: sync-team
@@ -46,7 +54,26 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:latest
 
       - name: Start the synchronization tool
-        if: github.event_name == 'merge_group'
         run: |
           aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
           cat output.json | python3 -m json.tool
+
+  # Summary job for the merge queue.
+  # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
+  conclusion:
+    name: CI
+    needs: [ test, deploy ]
+    # We need to ensure this job does *not* get skipped if its dependencies fail,
+    # because a skipped job is considered a success by GitHub. So we have to
+    # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run
+    # when the workflow is canceled manually.
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      # Manually check the status of all dependencies. `if: failure()` does not work.
+      - name: Conclusion
+        run: |
+          # Print the dependent jobs to see them in the CI log
+          jq -C <<< '${{ toJson(needs) }}'
+          # Check if all jobs that we depend on (in the needs array) were successful.
+          jq --exit-status 'all(.result == "success" or .result == "skipped")' <<< '${{ toJson(needs) }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'merge_group'
     steps:
+      - uses: actions/checkout@v4
+
       - name: Build the Docker container
         run: docker build -t sync-team .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   ci:
@@ -23,19 +25,19 @@ jobs:
         run: docker build -t sync-team .
 
       - name: Configure AWS credentials
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'merge_group'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--sync-team
           aws-region: us-west-1
 
       - name: Login to Amazon ECR Private
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'merge_group'
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Build, tag, and push docker image to Amazon ECR
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'merge_group'
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: sync-team
@@ -44,7 +46,7 @@ jobs:
           docker push $REGISTRY/$REPOSITORY:latest
 
       - name: Start the synchronization tool
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'merge_group'
         run: |
           aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
           cat output.json | python3 -m json.tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: github.event_name == 'merge_group'
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--sync-team
           aws-region: us-west-1

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -10,7 +10,7 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::890664054962:role/ci--rust-lang--sync-team
           aws-region: us-west-1


### PR DESCRIPTION
This should be helpful for moving the actual sync from AWS to GitHub, so that it can be performed in the merge queue directly, and prevent the PR from being merged if it fails. We shouldn't need a conclusion job here, because in CI the deploy part will be simply skipped.

This PR splits the CI workflow into multiple jobs. This allows us to configure the secrets only for the deploy job, and it will also allow us to turn the deploy/sync step into a reusable workflow in the future, to reduce duplication.

A small disadvantage is that the Docker build is now not tested on PRs, but it will be still tested in the merge queue. And we will remove the Docker build once we switch from AWS to GitHub deploy anway.

This will need an infra admin to:
- [ ] Configure merge queue on this repo.
- [ ] Reconfigure the AWS secret to work in the `deploy` environment. So [this](https://github.com/rust-lang/simpleinfra/blob/master/terraform/team-repo/ci.tf#L13) should be modified to look e.g. like [this](https://github.com/rust-lang/simpleinfra/blob/master/terragrunt/accounts/bors-prod/app/terragrunt.hcl#L13).