### PR TITLE
Synchronization from GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy -- -Dwarnings
-  deploy:
+  deploy_to_aws:
     name: Deploy
     needs: [ test ]
     environment: deploy
@@ -60,11 +60,16 @@ jobs:
           aws --region us-west-1 lambda invoke --function-name start-sync-team output.json
           cat output.json | python3 -m json.tool
 
+  sync:
+    name: Sync
+    if: github.event_name == 'merge_group'
+    uses: ./.github/workflows/deploy.yml
+
   # Summary job for the merge queue.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!
   conclusion:
     name: CI
-    needs: [ test, deploy ]
+    needs: [ test, sync, deploy_to_aws ]
     # We need to ensure this job does *not* get skipped if its dependencies fail,
     # because a skipped job is considered a success by GitHub. So we have to
     # overwrite `if:`. We use `!cancelled()` to ensure the job does still not get run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,9 @@ jobs:
 
   sync:
     name: Sync
-    if: github.event_name == 'merge_group'
+    #    if: github.event_name == 'merge_group'
     uses: ./.github/workflows/deploy.yml
+    secrets: inherit
 
   # Summary job for the merge queue.
   # ALL THE PREVIOUS JOBS NEED TO BE ADDED TO THE `needs` SECTION OF THIS JOB!

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+# Reusable workflow that checks out sync-team, builds it and performs the sync from the
+# current state of the team repository.
+name: Sync
+on:
+  workflow_call:
+
+jobs:
+  sync:
+    name: Perform sync
+    runs-on: ubuntu-latest
+    environment: deploy
+    steps:
+      # Uses either ${{ github.sha }} when invoked from this repository, otherwise the
+      # default branch.
+      - uses: actions/checkout@v4
+      # For now, just print the plan, to test the token
+      - name: Perform sync
+        run: |
+          GITHUB_TOKEN=${{ secrets.SYNC_GITHUB_TOKEN }} cargo run -- print-plan --services github


### PR DESCRIPTION
This PR introduces a reusable workflow that can be used for performing synchronization from GitHub. A couple of notes:
- Right now, the synchronization only performs a dry-run, just to check if the passed token is OK.
- The workflow is reusable so that we can also later use it from `team`.
- Right now, the synchronization is still performed through AWS.

An infra admin needs to configure the god token for the `deploy` environment, then we can check if the "dry run" works.

The following steps should be done in follow-up PRs (once we check that this works):
- Remove the AWS sync step and replace it with the GitHub sync. But still keep the AWS upload, so that `team` works.
- Modify `team` to invoke the reusable workflow from `sync-team` instead of invoking AWS.
- Remove the `deploy_to_aws` job and remove `Dockerfile`.
- Add an output to the sync workflow so that it can output its stdout (so that it can be posted in a comment).