### PR TITLE
remove ability to sync GitHub apps

### DIFF
--- a/src/github/api/mod.rs
+++ b/src/github/api/mod.rs
@@ -261,23 +261,9 @@ impl fmt::Display for RepoPermission {
     }
 }
 
-#[derive(serde::Deserialize, Debug)]
-pub(crate) struct OrgAppInstallation {
-    #[serde(rename = "id")]
-    pub(crate) installation_id: u64,
-    pub(crate) app_id: u64,
-}
-
-#[derive(serde::Deserialize, Debug)]
-pub(crate) struct RepoAppInstallation {
-    pub(crate) name: String,
-}
-
 #[derive(serde::Deserialize, Debug, Clone)]
 pub(crate) struct Repo {
     pub(crate) node_id: String,
-    #[serde(rename = "id")]
-    pub(crate) repo_id: u64,
     pub(crate) name: String,
     #[serde(alias = "owner", deserialize_with = "repo_owner")]
     pub(crate) org: String,

--- a/src/github/api/tokens.rs
+++ b/src/github/api/tokens.rs
@@ -46,10 +46,6 @@ impl GitHubTokens {
             GitHubTokens::Pat(pat) => Ok(pat),
         }
     }
-
-    pub fn is_pat(&self) -> bool {
-        matches!(self, GitHubTokens::Pat(_))
-    }
 }
 
 fn org_name_from_env_var(env_var: &str) -> Option<String> {

--- a/src/github/api/write.rs
+++ b/src/github/api/write.rs
@@ -237,7 +237,6 @@ impl GitHubWrite {
         if self.dry_run {
             Ok(Repo {
                 node_id: String::from("ID"),
-                repo_id: 0,
                 name: name.to_string(),
                 org: org.to_string(),
                 description: settings.description.clone(),
@@ -276,54 +275,6 @@ impl GitHubWrite {
         if !self.dry_run {
             self.client
                 .send(Method::PATCH, &GitHubUrl::repos(org, repo_name, "")?, &req)?;
-        }
-        Ok(())
-    }
-
-    pub(crate) fn add_repo_to_app_installation(
-        &self,
-        installation_id: u64,
-        repository_id: u64,
-        org: &str,
-    ) -> anyhow::Result<()> {
-        debug!("Adding repository {repository_id} to installation {installation_id}");
-        if !self.dry_run {
-            self.client
-                .req(
-                    Method::PUT,
-                    &GitHubUrl::new(
-                        &format!(
-                            "user/installations/{installation_id}/repositories/{repository_id}"
-                        ),
-                        org,
-                    ),
-                )?
-                .send()?
-                .custom_error_for_status()?;
-        }
-        Ok(())
-    }
-
-    pub(crate) fn remove_repo_from_app_installation(
-        &self,
-        installation_id: u64,
-        repository_id: u64,
-        org: &str,
-    ) -> anyhow::Result<()> {
-        debug!("Removing repository {repository_id} from installation {installation_id}");
-        if !self.dry_run {
-            self.client
-                .req(
-                    Method::DELETE,
-                    &GitHubUrl::new(
-                        &format!(
-                            "user/installations/{installation_id}/repositories/{repository_id}"
-                        ),
-                        org,
-                    ),
-                )?
-                .send()?
-                .custom_error_for_status()?;
         }
         Ok(())
     }

--- a/src/github/tests/mod.rs
+++ b/src/github/tests/mod.rs
@@ -223,7 +223,6 @@ fn repo_change_description() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "foo",
@@ -240,7 +239,6 @@ fn repo_change_description() {
                 ),
                 permission_diffs: [],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -262,7 +260,6 @@ fn repo_change_homepage() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -283,7 +280,6 @@ fn repo_change_homepage() {
                 ),
                 permission_diffs: [],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -351,7 +347,6 @@ fn repo_create() {
                         },
                     ),
                 ],
-                app_installations: [],
             },
         ),
     ]
@@ -380,7 +375,6 @@ fn repo_add_member() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -406,7 +400,6 @@ fn repo_add_member() {
                     },
                 ],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -434,7 +427,6 @@ fn repo_change_member_permissions() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -461,7 +453,6 @@ fn repo_change_member_permissions() {
                     },
                 ],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -484,7 +475,6 @@ fn repo_remove_member() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -510,7 +500,6 @@ fn repo_remove_member() {
                     },
                 ],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -535,7 +524,6 @@ fn repo_add_team() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -561,7 +549,6 @@ fn repo_add_team() {
                     },
                 ],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -584,7 +571,6 @@ fn repo_change_team_permissions() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -611,7 +597,6 @@ fn repo_change_team_permissions() {
                     },
                 ],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -634,7 +619,6 @@ fn repo_remove_team() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -660,7 +644,6 @@ fn repo_remove_team() {
                     },
                 ],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -683,7 +666,6 @@ fn repo_archive_repo() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -700,7 +682,6 @@ fn repo_archive_repo() {
                 ),
                 permission_diffs: [],
                 branch_protection_diffs: [],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -726,7 +707,6 @@ fn repo_add_branch_protection() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -775,7 +755,6 @@ fn repo_add_branch_protection() {
                         ),
                     },
                 ],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -819,7 +798,6 @@ fn repo_update_branch_protection() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -866,7 +844,6 @@ fn repo_update_branch_protection() {
                         ),
                     },
                 ],
-                app_installation_diffs: [],
             },
         ),
     ]
@@ -896,7 +873,6 @@ fn repo_remove_branch_protection() {
                 org: "rust-lang",
                 name: "repo1",
                 repo_node_id: "0",
-                repo_id: 0,
                 settings_diff: (
                     RepoSettings {
                         description: "",
@@ -920,7 +896,6 @@ fn repo_remove_branch_protection() {
                         ),
                     },
                 ],
-                app_installation_diffs: [],
             },
         ),
     ]

--- a/src/github/tests/test_utils.rs
+++ b/src/github/tests/test_utils.rs
@@ -7,8 +7,7 @@ use rust_team_data::v1::{
 };
 
 use crate::github::api::{
-    BranchProtection, GithubRead, OrgAppInstallation, Repo, RepoAppInstallation, RepoTeam,
-    RepoUser, Team, TeamMember, TeamPrivacy, TeamRole,
+    BranchProtection, GithubRead, Repo, RepoTeam, RepoUser, Team, TeamMember, TeamPrivacy, TeamRole,
 };
 use crate::github::{
     RepoDiff, SyncGitHub, TeamDiff, api, construct_branch_protection, convert_permission,
@@ -115,7 +114,6 @@ impl DataModel {
             repos.insert(
                 repo.name.clone(),
                 Repo {
-                    repo_id: repos.len() as u64,
                     node_id: repos.len().to_string(),
                     name: repo.name.clone(),
                     org: DEFAULT_ORG.to_string(),
@@ -455,18 +453,6 @@ impl GithubRead for GithubMock {
             .unwrap_or_default()
             .into_iter()
             .collect())
-    }
-
-    fn org_app_installations(&self, _org: &str) -> anyhow::Result<Vec<OrgAppInstallation>> {
-        Ok(vec![])
-    }
-
-    fn app_installation_repos(
-        &self,
-        _installation_id: u64,
-        _org: &str,
-    ) -> anyhow::Result<Vec<RepoAppInstallation>> {
-        Ok(vec![])
     }
 
     fn org_teams(&self, org: &str) -> anyhow::Result<Vec<(String, String)>> {


### PR DESCRIPTION
solves https://github.com/rust-lang/sync-team/issues/121
Discussed in [zulip](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/sync-team.20dry.20run.20workflow/near/506091368)[#t-infra > sync-team dry run workflow @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/242791-t-infra/topic/sync-team.20dry.20run.20workflow/near/506091368).

After this change, teams need to request in t-infra to install a GitHub app for them. The `bots` array of the `team` pr won't work anymore.

After this is merged, we can remove the `bots` array from the team repo
